### PR TITLE
Pin dependencies to for 1.35 release

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,9 +29,23 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
+  charmcraft:
+    name: Determine Charmcraft Channel
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.charmcraft.outputs.channel }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Read charmcraft version file
+        id: charmcraft
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+
   lib-check:
     name: Check libraries
     runs-on: ubuntu-22.04
+    needs:
+    - charmcraft
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,26 +56,25 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          charmcraft-channel: ${{ needs.charmcraft.outputs.channel }}
 
   integration-test:
     name: Integration tests (microk8s)
     runs-on: ubuntu-22.04
     needs:
+      - charmcraft
       - lint
       - unit-test
       - lib-check
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Read charmcraft version file
-        id: charmcraft
-        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.30-strict/stable
-          charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
+          channel: 1.35-strict/stable
+          charmcraft-channel: ${{ needs.charmcraft.outputs.channel }}
           juju-channel: 3/stable
           microk8s-group: snap_microk8s
       - name: Setup MetalLB

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -12,6 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        uses: actions/checkout@v4
+      - name: Read charmcraft version file
+        id: charmcraft
+        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+      - name: Checkout
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
         with:
           fetch-depth: 0
@@ -21,6 +26,7 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+          charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
 
       - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
         id: generate-token

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,15 +15,6 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "22.04"
-      architectures: ["armhf"]
-    run-on:
-    - name: "ubuntu"
-      channel: "22.04"
-      architectures:
-        - armhf
-  - build-on:
-    - name: "ubuntu"
-      channel: "22.04"
       architectures: ["arm64"]
     run-on:
     - name: "ubuntu"
@@ -50,11 +41,16 @@ bases:
         - s390x
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    plugin: charm
+    override-build: |
+      craftctl default
+      git -C $CRAFT_PROJECT_DIR rev-parse --short HEAD > version
+    charm-binary-python-packages:
+    - maturin
     build-packages:
-      - git
-      - libffi-dev
-      - libssl-dev
-      - pkg-config
-      - rustc
-      - cargo
+    - git
+    - libffi-dev
+    - libssl-dev
+    - pkg-config
+    - rustc
+    - cargo

--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,19 +276,17 @@ import copy
 import json
 import logging
 import uuid
-from collections import defaultdict
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from cryptography import x509
-from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import pkcs12
-from cryptography.x509.extensions import Extension, ExtensionNotFound
-from jsonschema import exceptions, validate  # type: ignore[import]
+from cryptography.x509.oid import ExtensionOID
+from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
     CharmEvents,
@@ -299,7 +297,7 @@ from ops.charm import (
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import SecretNotFoundError
+from ops.model import ModelError, Relation, RelationDataContent, SecretNotFoundError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
@@ -309,13 +307,13 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 30
 
 PYDEPS = ["cryptography", "jsonschema"]
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/requirer.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/requirer.json",
     "type": "object",
     "title": "`tls_certificates` requirer root schema",
     "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
@@ -336,7 +334,10 @@ REQUIRER_JSON_SCHEMA = {
             "type": "array",
             "items": {
                 "type": "object",
-                "properties": {"certificate_signing_request": {"type": "string"}},
+                "properties": {
+                    "certificate_signing_request": {"type": "string"},
+                    "ca": {"type": "boolean"},
+                },
                 "required": ["certificate_signing_request"],
             },
         }
@@ -347,7 +348,7 @@ REQUIRER_JSON_SCHEMA = {
 
 PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/provider.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/provider.json",
     "type": "object",
     "title": "`tls_certificates` provider root schema",
     "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
@@ -439,7 +440,7 @@ class CertificateAvailableEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate": self.certificate,
             "certificate_signing_request": self.certificate_signing_request,
@@ -448,7 +449,7 @@ class CertificateAvailableEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.ca = snapshot["ca"]
@@ -458,7 +459,7 @@ class CertificateAvailableEvent(EventBase):
 class CertificateExpiringEvent(EventBase):
     """Charm Event triggered when a TLS certificate is almost expired."""
 
-    def __init__(self, handle, certificate: str, expiry: str):
+    def __init__(self, handle: Handle, certificate: str, expiry: str):
         """CertificateExpiringEvent.
 
         Args:
@@ -472,11 +473,11 @@ class CertificateExpiringEvent(EventBase):
         self.expiry = expiry
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {"certificate": self.certificate, "expiry": self.expiry}
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.expiry = snapshot["expiry"]
 
@@ -501,7 +502,7 @@ class CertificateInvalidatedEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "reason": self.reason,
             "certificate_signing_request": self.certificate_signing_request,
@@ -511,7 +512,7 @@ class CertificateInvalidatedEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.reason = snapshot["reason"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.certificate = snapshot["certificate"]
@@ -526,33 +527,42 @@ class AllCertificatesInvalidatedEvent(EventBase):
         super().__init__(handle)
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {}
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         pass
 
 
 class CertificateCreationRequestEvent(EventBase):
     """Charm Event triggered when a TLS certificate is required."""
 
-    def __init__(self, handle: Handle, certificate_signing_request: str, relation_id: int):
+    def __init__(
+        self,
+        handle: Handle,
+        certificate_signing_request: str,
+        relation_id: int,
+        is_ca: bool = False,
+    ):
         super().__init__(handle)
         self.certificate_signing_request = certificate_signing_request
         self.relation_id = relation_id
+        self.is_ca = is_ca
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate_signing_request": self.certificate_signing_request,
             "relation_id": self.relation_id,
+            "is_ca": self.is_ca,
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.relation_id = snapshot["relation_id"]
+        self.is_ca = snapshot["is_ca"]
 
 
 class CertificateRevocationRequestEvent(EventBase):
@@ -573,7 +583,7 @@ class CertificateRevocationRequestEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate": self.certificate,
             "certificate_signing_request": self.certificate_signing_request,
@@ -582,31 +592,70 @@ class CertificateRevocationRequestEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.ca = snapshot["ca"]
         self.chain = snapshot["chain"]
 
 
-def _load_relation_data(raw_relation_data: dict) -> dict:
-    """Loads relation data from the relation data bag.
+def _load_relation_data(relation_data_content: RelationDataContent) -> dict:
+    """Load relation data from the relation data bag.
 
     Json loads all data.
 
     Args:
-        raw_relation_data: Relation data from the databag
+        relation_data_content: Relation data from the databag
 
     Returns:
         dict: Relation data in dict format.
     """
-    certificate_data = dict()
-    for key in raw_relation_data:
-        try:
-            certificate_data[key] = json.loads(raw_relation_data[key])
-        except (json.decoder.JSONDecodeError, TypeError):
-            certificate_data[key] = raw_relation_data[key]
+    certificate_data = {}
+    try:
+        for key in relation_data_content:
+            try:
+                certificate_data[key] = json.loads(relation_data_content[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                certificate_data[key] = relation_data_content[key]
+    except ModelError:
+        pass
     return certificate_data
+
+
+def _get_closest_future_time(
+    expiry_notification_time: datetime, expiry_time: datetime
+) -> datetime:
+    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
+
+    Args:
+        expiry_notification_time (datetime): Notification time of impending expiration
+        expiry_time (datetime): Expiration time
+
+    Returns:
+        datetime: expiry_notification_time if not in the past, expiry_time otherwise
+    """
+    return (
+        expiry_notification_time
+        if datetime.now(timezone.utc) < expiry_notification_time
+        else expiry_time
+    )
+
+
+def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
+    """Extract expiry time from a certificate string.
+
+    Args:
+        certificate (str): x509 certificate as a string
+
+    Returns:
+        Optional[datetime]: Expiry datetime or None
+    """
+    try:
+        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+        return certificate_object.not_valid_after_utc
+    except ValueError:
+        logger.warning("Could not load certificate.")
+        return None
 
 
 def generate_ca(
@@ -616,11 +665,11 @@ def generate_ca(
     validity: int = 365,
     country: str = "US",
 ) -> bytes:
-    """Generates a CA Certificate.
+    """Generate a CA Certificate.
 
     Args:
         private_key (bytes): Private key
-        subject (str): Certificate subject
+        subject (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         private_key_password (bytes): Private key password
         validity (int): Certificate validity time (in days)
         country (str): Certificate Issuing country
@@ -631,7 +680,7 @@ def generate_ca(
     private_key_object = serialization.load_pem_private_key(
         private_key, password=private_key_password
     )
-    subject = issuer = x509.Name(
+    subject_name = x509.Name(
         [
             x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
@@ -641,14 +690,25 @@ def generate_ca(
         private_key_object.public_key()  # type: ignore[arg-type]
     )
     subject_identifier = key_identifier = subject_identifier_object.public_bytes()
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        key_encipherment=True,
+        key_cert_sign=True,
+        key_agreement=False,
+        content_commitment=False,
+        data_encipherment=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
             x509.AuthorityKeyIdentifier(
@@ -658,6 +718,7 @@ def generate_ca(
             ),
             critical=False,
         )
+        .add_extension(key_usage, critical=True)
         .add_extension(
             x509.BasicConstraints(ca=True, path_length=None),
             critical=True,
@@ -667,6 +728,105 @@ def generate_ca(
     return cert.public_bytes(serialization.Encoding.PEM)
 
 
+def get_certificate_extensions(
+    authority_key_identifier: bytes,
+    csr: x509.CertificateSigningRequest,
+    alt_names: Optional[List[str]],
+    is_ca: bool,
+) -> List[x509.Extension]:
+    """Generate a list of certificate extensions from a CSR and other known information.
+
+    Args:
+        authority_key_identifier (bytes): Authority key identifier
+        csr (x509.CertificateSigningRequest): CSR
+        alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        List[x509.Extension]: List of extensions
+    """
+    cert_extensions_list: List[x509.Extension] = [
+        x509.Extension(
+            oid=ExtensionOID.AUTHORITY_KEY_IDENTIFIER,
+            value=x509.AuthorityKeyIdentifier(
+                key_identifier=authority_key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_KEY_IDENTIFIER,
+            value=x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.BASIC_CONSTRAINTS,
+            critical=True,
+            value=x509.BasicConstraints(ca=is_ca, path_length=None),
+        ),
+    ]
+
+    sans: List[x509.GeneralName] = []
+    san_alt_names = [x509.DNSName(name) for name in alt_names] if alt_names else []
+    sans.extend(san_alt_names)
+    try:
+        loaded_san_ext = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans.extend(
+            [x509.DNSName(name) for name in loaded_san_ext.value.get_values_for_type(x509.DNSName)]
+        )
+        sans.extend(
+            [x509.IPAddress(ip) for ip in loaded_san_ext.value.get_values_for_type(x509.IPAddress)]
+        )
+        sans.extend(
+            [
+                x509.RegisteredID(oid)
+                for oid in loaded_san_ext.value.get_values_for_type(x509.RegisteredID)
+            ]
+        )
+    except x509.ExtensionNotFound:
+        pass
+
+    if sans:
+        cert_extensions_list.append(
+            x509.Extension(
+                oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+                critical=False,
+                value=x509.SubjectAlternativeName(sans),
+            )
+        )
+
+    if is_ca:
+        cert_extensions_list.append(
+            x509.Extension(
+                ExtensionOID.KEY_USAGE,
+                critical=True,
+                value=x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+            )
+        )
+
+    existing_oids = {ext.oid for ext in cert_extensions_list}
+    for extension in csr.extensions:
+        if extension.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME:
+            continue
+        if extension.oid in existing_oids:
+            logger.warning("Extension %s is managed by the TLS provider, ignoring.", extension.oid)
+            continue
+        cert_extensions_list.append(extension)
+
+    return cert_extensions_list
+
+
 def generate_certificate(
     csr: bytes,
     ca: bytes,
@@ -674,8 +834,9 @@ def generate_certificate(
     ca_key_password: Optional[bytes] = None,
     validity: int = 365,
     alt_names: Optional[List[str]] = None,
+    is_ca: bool = False,
 ) -> bytes:
-    """Generates a TLS certificate based on a CSR.
+    """Generate a TLS certificate based on a CSR.
 
     Args:
         csr (bytes): CSR
@@ -684,13 +845,15 @@ def generate_certificate(
         ca_key_password: CA private key password
         validity (int): Certificate validity (in days)
         alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
+        is_ca (bool): Whether the certificate is a CA certificate
 
     Returns:
         bytes: Certificate
     """
     csr_object = x509.load_pem_x509_csr(csr)
     subject = csr_object.subject
-    issuer = x509.load_pem_x509_certificate(ca).issuer
+    ca_pem = x509.load_pem_x509_certificate(ca)
+    issuer = ca_pem.issuer
     private_key = serialization.load_pem_private_key(ca_key, password=ca_key_password)
 
     certificate_builder = (
@@ -699,39 +862,26 @@ def generate_certificate(
         .issuer_name(issuer)
         .public_key(csr_object.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
     )
-
-    extensions_list = csr_object.extensions
-    san_ext: Optional[x509.Extension] = None
-    if alt_names:
-        full_sans_dns = alt_names.copy()
+    extensions = get_certificate_extensions(
+        authority_key_identifier=ca_pem.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value.key_identifier,
+        csr=csr_object,
+        alt_names=alt_names,
+        is_ca=is_ca,
+    )
+    for extension in extensions:
         try:
-            loaded_san_ext = csr_object.extensions.get_extension_for_class(
-                x509.SubjectAlternativeName
+            certificate_builder = certificate_builder.add_extension(
+                extval=extension.value,
+                critical=extension.critical,
             )
-            full_sans_dns.extend(loaded_san_ext.value.get_values_for_type(x509.DNSName))
-        except ExtensionNotFound:
-            pass
-        finally:
-            san_ext = Extension(
-                ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
-                False,
-                x509.SubjectAlternativeName([x509.DNSName(name) for name in full_sans_dns]),
-            )
-            if not extensions_list:
-                extensions_list = x509.Extensions([san_ext])
+        except ValueError as e:
+            logger.warning("Failed to add extension %s: %s", extension.oid, e)
 
-    for extension in extensions_list:
-        if extension.value.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME and san_ext:
-            extension = san_ext
-
-        certificate_builder = certificate_builder.add_extension(
-            extension.value,
-            critical=extension.critical,
-        )
-    certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
     return cert.public_bytes(serialization.Encoding.PEM)
 
@@ -742,7 +892,7 @@ def generate_pfx_package(
     package_password: str,
     private_key_password: Optional[bytes] = None,
 ) -> bytes:
-    """Generates a PFX package to contain the TLS certificate and private key.
+    """Generate a PFX package to contain the TLS certificate and private key.
 
     Args:
         certificate (bytes): TLS certificate
@@ -773,7 +923,7 @@ def generate_private_key(
     key_size: int = 2048,
     public_exponent: int = 65537,
 ) -> bytes:
-    """Generates a private key.
+    """Generate a private key.
 
     Args:
         password (bytes): Password for decrypting the private key
@@ -790,14 +940,16 @@ def generate_private_key(
     key_bytes = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.TraditionalOpenSSL,
-        encryption_algorithm=serialization.BestAvailableEncryption(password)
-        if password
-        else serialization.NoEncryption(),
+        encryption_algorithm=(
+            serialization.BestAvailableEncryption(password)
+            if password
+            else serialization.NoEncryption()
+        ),
     )
     return key_bytes
 
 
-def generate_csr(
+def generate_csr(  # noqa: C901
     private_key: bytes,
     subject: str,
     add_unique_id_to_subject_name: bool = True,
@@ -811,11 +963,11 @@ def generate_csr(
     sans_dns: Optional[List[str]] = None,
     additional_critical_extensions: Optional[List] = None,
 ) -> bytes:
-    """Generates a CSR using private key and subject.
+    """Generate a CSR using private key and subject.
 
     Args:
         private_key (bytes): Private key
-        subject (str): CSR Subject.
+        subject (str): CSR Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
             subject name. Always leave to "True" when the CSR is used to request certificates
             using the tls-certificates relation.
@@ -828,7 +980,7 @@ def generate_csr(
         sans_oid (list): List of registered ID SANs
         sans_dns (list): List of DNS subject alternative names (similar to the arg: sans)
         sans_ip (list): List of IP subject alternative names
-        additional_critical_extensions (list): List if critical additional extension objects.
+        additional_critical_extensions (list): List of critical additional extension objects.
             Object must be a x509 ExtensionType.
 
     Returns:
@@ -869,6 +1021,38 @@ def generate_csr(
     return signed_certificate.public_bytes(serialization.Encoding.PEM)
 
 
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    Args:
+        csr (str): Certificate Signing Request as a string
+        cert (str): Certificate as a string
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if (
+            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
+            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
+        ):
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
+
+
 class CertificatesProviderCharmEvents(CharmEvents):
     """List of events that the TLS Certificates provider charm can leverage."""
 
@@ -888,7 +1072,7 @@ class CertificatesRequirerCharmEvents(CharmEvents):
 class TLSCertificatesProvidesV2(Object):
     """TLS certificates provider class to be instantiated by TLS certificates providers."""
 
-    on = CertificatesProviderCharmEvents()
+    on = CertificatesProviderCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -898,6 +1082,22 @@ class TLSCertificatesProvidesV2(Object):
         self.charm = charm
         self.relationship_name = relationship_name
 
+    def _load_app_relation_data(self, relation: Relation) -> dict:
+        """Load relation data from the application relation data bag.
+
+        Json loads all data.
+
+        Args:
+            relation: Relation data from the application databag
+
+        Returns:
+            dict: Relation data in dict format.
+        """
+        # If unit is not leader, it does not try to reach relation data.
+        if not self.model.unit.is_leader():
+            return {}
+        return _load_relation_data(relation.data[self.charm.app])
+
     def _add_certificate(
         self,
         relation_id: int,
@@ -906,7 +1106,7 @@ class TLSCertificatesProvidesV2(Object):
         ca: str,
         chain: List[str],
     ) -> None:
-        """Adds certificate to relation data.
+        """Add certificate to relation data.
 
         Args:
             relation_id (int): Relation id
@@ -932,7 +1132,7 @@ class TLSCertificatesProvidesV2(Object):
             "ca": ca,
             "chain": chain,
         }
-        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         if new_certificate in certificates:
@@ -947,7 +1147,7 @@ class TLSCertificatesProvidesV2(Object):
         certificate: Optional[str] = None,
         certificate_signing_request: Optional[str] = None,
     ) -> None:
-        """Removes certificate from a given relation based on user provided certificate or csr.
+        """Remove certificate from a given relation based on user provided certificate or csr.
 
         Args:
             relation_id (int): Relation id
@@ -965,7 +1165,7 @@ class TLSCertificatesProvidesV2(Object):
             raise RuntimeError(
                 f"Relation {self.relationship_name} with relation id {relation_id} does not exist"
             )
-        provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
         certificates = copy.deepcopy(provider_certificates)
         for certificate_dict in certificates:
@@ -980,7 +1180,7 @@ class TLSCertificatesProvidesV2(Object):
 
     @staticmethod
     def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Uses JSON schema validator to validate relation data content.
+        """Use JSON schema validator to validate relation data content.
 
         Args:
             certificates_data (dict): Certificate data dictionary as retrieved from relation data.
@@ -995,12 +1195,12 @@ class TLSCertificatesProvidesV2(Object):
             return False
 
     def revoke_all_certificates(self) -> None:
-        """Revokes all certificates of this provider.
+        """Revoke all certificates of this provider.
 
         This method is meant to be used when the Root CA has changed.
         """
         for relation in self.model.relations[self.relationship_name]:
-            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = copy.deepcopy(provider_relation_data.get("certificates", []))
             for certificate in provider_certificates:
                 certificate["revoked"] = True
@@ -1014,7 +1214,7 @@ class TLSCertificatesProvidesV2(Object):
         chain: List[str],
         relation_id: int,
     ) -> None:
-        """Adds certificates to relation data.
+        """Add certificates to relation data.
 
         Args:
             certificate (str): Certificate
@@ -1046,7 +1246,7 @@ class TLSCertificatesProvidesV2(Object):
         )
 
     def remove_certificate(self, certificate: str) -> None:
-        """Removes a given certificate from relation data.
+        """Remove a given certificate from relation data.
 
         Args:
             certificate (str): TLS Certificate
@@ -1062,8 +1262,8 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, Dict[str, str]]:
-        """Returns a dictionary of issued certificates.
+    ) -> Dict[str, List[Dict[str, str]]]:
+        """Return a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
         Certificates are returned per application name and CSR.
@@ -1071,23 +1271,34 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        certificates: Dict[str, List[Dict[str, str]]] = {}
         relations = (
-            [self.model.relations[self.relationship_name][relation_id]]
-            if relation_id
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
-            provider_relation_data = _load_relation_data(relation.data[self.charm.app])
+            provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = provider_relation_data.get("certificates", [])
+
+            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
-                certificates[relation.app.name].update(  # type: ignore[union-attr]
-                    {certificate["certificate_signing_request"]: certificate["certificate"]}
-                )
+                if not certificate.get("revoked", False):
+                    certificates[relation.app.name].append(  # type: ignore[union-attr]
+                        {
+                            "csr": certificate["certificate_signing_request"],
+                            "certificate": certificate["certificate"],
+                        }
+                    )
+
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handle relation changed event.
 
         Looks at the relation data and either emits:
         - certificate request event: If the unit relation data contains a CSR for which
@@ -1101,9 +1312,13 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             None
         """
-        assert event.unit is not None
+        if event.unit is None:
+            logger.error("Relation_changed event does not have a unit.")
+            return
+        if not self.model.unit.is_leader():
+            return
         requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
-        provider_relation_data = _load_relation_data(event.relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(event.relation)
         if not self._relation_data_is_valid(requirer_relation_data):
             logger.debug("Relation data did not pass JSON Schema validation")
             return
@@ -1113,20 +1328,24 @@ class TLSCertificatesProvidesV2(Object):
             certificate_creation_request["certificate_signing_request"]
             for certificate_creation_request in provider_certificates
         ]
-        requirer_unit_csrs = [
-            certificate_creation_request["certificate_signing_request"]
+        requirer_unit_certificate_requests = [
+            {
+                "csr": certificate_creation_request["certificate_signing_request"],
+                "is_ca": certificate_creation_request.get("ca", False),
+            }
             for certificate_creation_request in requirer_csrs
         ]
-        for certificate_signing_request in requirer_unit_csrs:
-            if certificate_signing_request not in provider_csrs:
+        for certificate_request in requirer_unit_certificate_requests:
+            if certificate_request["csr"] not in provider_csrs:
                 self.on.certificate_creation_request.emit(
-                    certificate_signing_request=certificate_signing_request,
+                    certificate_signing_request=certificate_request["csr"],
                     relation_id=event.relation.id,
+                    is_ca=certificate_request["is_ca"],
                 )
         self._revoke_certificates_for_which_no_csr_exists(relation_id=event.relation.id)
 
     def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
-        """Revokes certificates for which no unit has a CSR.
+        """Revoke certificates for which no unit has a CSR.
 
         Goes through all generated certificates and compare against the list of CSRs for all units
         of a given relationship.
@@ -1142,7 +1361,7 @@ class TLSCertificatesProvidesV2(Object):
         )
         if not certificates_relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
-        provider_relation_data = _load_relation_data(certificates_relation.data[self.charm.app])
+        provider_relation_data = self._load_app_relation_data(certificates_relation)
         list_of_csrs: List[str] = []
         for unit in certificates_relation.units:
             requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
@@ -1159,11 +1378,112 @@ class TLSCertificatesProvidesV2(Object):
                 )
                 self.remove_certificate(certificate=certificate["certificate"])
 
+    def get_outstanding_certificate_requests(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Return CSR's for which no certificate has been issued.
+
+        Example return: [
+            {
+                "relation_id": 0,
+                "application_name": "tls-certificates-requirer",
+                "unit_name": "tls-certificates-requirer/0",
+                "unit_csrs": [
+                    {
+                        "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                        "is_ca": false
+                    }
+                ]
+            }
+        ]
+
+        Args:
+            relation_id (int): Relation id
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            that don't have a certificate issued.
+        """
+        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs(relation_id=relation_id))
+        filtered_all_unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
+        for unit_csr_mapping in all_unit_csr_mappings:
+            csrs_without_certs = []
+            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
+                if not self.certificate_issued_for_csr(
+                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
+                    csr=csr["certificate_signing_request"],  # type: ignore[index]
+                    relation_id=relation_id,
+                ):
+                    csrs_without_certs.append(csr)
+            if csrs_without_certs:
+                unit_csr_mapping["unit_csrs"] = csrs_without_certs  # type: ignore[assignment]
+                filtered_all_unit_csr_mappings.append(unit_csr_mapping)
+        return filtered_all_unit_csr_mappings
+
+    def get_requirer_csrs(
+        self, relation_id: Optional[int] = None
+    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+        """Return a list of requirers' CSRs grouped by unit.
+
+        It returns CSRs from all relations if relation_id is not specified.
+        CSRs are returned per relation id, application name and unit name.
+
+        Returns:
+            list: List of dictionaries that contain the unit's csrs
+            with the following information
+            relation_id, application_name and unit_name.
+        """
+        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
+
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relationship_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relationship_name, [])
+        )
+
+        for relation in relations:
+            for unit in relation.units:
+                requirer_relation_data = _load_relation_data(relation.data[unit])
+                unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
+                unit_csr_mappings.append(
+                    {
+                        "relation_id": relation.id,
+                        "application_name": relation.app.name,  # type: ignore[union-attr]
+                        "unit_name": unit.name,
+                        "unit_csrs": unit_csrs_list,
+                    }
+                )
+        return unit_csr_mappings
+
+    def certificate_issued_for_csr(
+        self, app_name: str, csr: str, relation_id: Optional[int]
+    ) -> bool:
+        """Check whether a certificate has been issued for a given CSR.
+
+        Args:
+            app_name (str): Application name that the CSR belongs to.
+            csr (str): Certificate Signing Request.
+            relation_id (Optional[int]): Relation ID
+        Returns:
+            bool: True/False depending on whether a certificate has been issued for the given CSR.
+        """
+        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)[
+            app_name
+        ]
+        for issued_pair in issued_certificates_per_csr:
+            if "csr" in issued_pair and issued_pair["csr"] == csr:
+                return csr_matches_certificate(csr, issued_pair["certificate"])
+        return False
+
 
 class TLSCertificatesRequiresV2(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = CertificatesRequirerCharmEvents()
+    on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(
         self,
@@ -1171,7 +1491,7 @@ class TLSCertificatesRequiresV2(Object):
         relationship_name: str,
         expiry_notification_time: int = 168,
     ):
-        """Generates/use private key and observes relation changed event.
+        """Generate/use private key and observes relation changed event.
 
         Args:
             charm: Charm object
@@ -1195,8 +1515,17 @@ class TLSCertificatesRequiresV2(Object):
             self.framework.observe(charm.on.update_status, self._on_update_status)
 
     @property
-    def _requirer_csrs(self) -> List[Dict[str, str]]:
-        """Returns list of requirer CSR's from relation data."""
+    def _requirer_csrs(self) -> List[Dict[str, Union[bool, str]]]:
+        """Return list of requirer's CSRs from relation unit data.
+
+        Example:
+            [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                    "ca": false
+                }
+            ]
+        """
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             raise RuntimeError(f"Relation {self.relationship_name} does not exist")
@@ -1205,7 +1534,7 @@ class TLSCertificatesRequiresV2(Object):
 
     @property
     def _provider_certificates(self) -> List[Dict[str, str]]:
-        """Returns list of certificates from the provider's relation data."""
+        """Return list of certificates from the provider's relation data."""
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1219,11 +1548,12 @@ class TLSCertificatesRequiresV2(Object):
             return []
         return provider_relation_data.get("certificates", [])
 
-    def _add_requirer_csr(self, csr: str) -> None:
-        """Adds CSR to relation data.
+    def _add_requirer_csr(self, csr: str, is_ca: bool) -> None:
+        """Add CSR to relation data.
 
         Args:
             csr (str): Certificate Signing Request
+            is_ca (bool): Whether the certificate is a CA certificate
 
         Returns:
             None
@@ -1234,7 +1564,10 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        new_csr_dict = {"certificate_signing_request": csr}
+        new_csr_dict: Dict[str, Union[bool, str]] = {
+            "certificate_signing_request": csr,
+            "ca": is_ca,
+        }
         if new_csr_dict in self._requirer_csrs:
             logger.info("CSR already in relation data - Doing nothing")
             return
@@ -1243,7 +1576,7 @@ class TLSCertificatesRequiresV2(Object):
         relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
 
     def _remove_requirer_csr(self, csr: str) -> None:
-        """Removes CSR from relation data.
+        """Remove CSR from relation data.
 
         Args:
             csr (str): Certificate signing request
@@ -1258,18 +1591,22 @@ class TLSCertificatesRequiresV2(Object):
                 f"The certificate request can't be completed"
             )
         requirer_csrs = copy.deepcopy(self._requirer_csrs)
-        csr_dict = {"certificate_signing_request": csr}
-        if csr_dict not in requirer_csrs:
-            logger.info("CSR not in relation data - Doing nothing")
+        if not requirer_csrs:
+            logger.info("No CSRs in relation data - Doing nothing")
             return
-        requirer_csrs.remove(csr_dict)
+        for requirer_csr in requirer_csrs:
+            if requirer_csr["certificate_signing_request"] == csr:
+                requirer_csrs.remove(requirer_csr)
         relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
 
-    def request_certificate_creation(self, certificate_signing_request: bytes) -> None:
+    def request_certificate_creation(
+        self, certificate_signing_request: bytes, is_ca: bool = False
+    ) -> None:
         """Request TLS certificate to provider charm.
 
         Args:
             certificate_signing_request (bytes): Certificate Signing Request
+            is_ca (bool): Whether the certificate is a CA certificate
 
         Returns:
             None
@@ -1280,11 +1617,11 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        self._add_requirer_csr(certificate_signing_request.decode().strip())
+        self._add_requirer_csr(certificate_signing_request.decode().strip(), is_ca=is_ca)
         logger.info("Certificate request sent to provider")
 
     def request_certificate_revocation(self, certificate_signing_request: bytes) -> None:
-        """Removes CSR from relation data.
+        """Remove CSR from relation data.
 
         The provider of this relation is then expected to remove certificates associated to this
         CSR from the relation data as well and emit a request_certificate_revocation event for the
@@ -1302,7 +1639,7 @@ class TLSCertificatesRequiresV2(Object):
     def request_certificate_renewal(
         self, old_certificate_signing_request: bytes, new_certificate_signing_request: bytes
     ) -> None:
-        """Renews certificate.
+        """Renew certificate.
 
         Removes old CSR from relation data and adds new one.
 
@@ -1324,9 +1661,95 @@ class TLSCertificatesRequiresV2(Object):
         )
         logger.info("Certificate renewal request completed.")
 
+    def get_assigned_certificates(self) -> List[Dict[str, str]]:
+        """Get a list of certificates that were assigned to this unit.
+
+        Returns:
+            List of certificates. For example:
+            [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----...",
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----..."
+                    ],
+                    "certificate": "-----BEGIN CERTIFICATE-----...",
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                }
+            ]
+        """
+        final_list = []
+        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            assert isinstance(csr["certificate_signing_request"], str)
+            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
+                final_list.append(cert)
+        return final_list
+
+    def get_expiring_certificates(self) -> List[Dict[str, str]]:
+        """Get a list of certificates that were assigned to this unit that are expiring or expired.
+
+        Returns:
+            List of certificates. For example:
+            [
+                {
+                    "ca": "-----BEGIN CERTIFICATE-----...",
+                    "chain": [
+                        "-----BEGIN CERTIFICATE-----..."
+                    ],
+                    "certificate": "-----BEGIN CERTIFICATE-----...",
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                }
+            ]
+        """
+        final_list = []
+        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            assert isinstance(csr["certificate_signing_request"], str)
+            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
+                expiry_time = _get_certificate_expiry_time(cert["certificate"])
+                if not expiry_time:
+                    continue
+                expiry_notification_time = expiry_time - timedelta(
+                    hours=self.expiry_notification_time
+                )
+                if datetime.now(timezone.utc) > expiry_notification_time:
+                    final_list.append(cert)
+        return final_list
+
+    def get_certificate_signing_requests(
+        self,
+        fulfilled_only: bool = False,
+        unfulfilled_only: bool = False,
+    ) -> List[Dict[str, Union[bool, str]]]:
+        """Get the list of CSR's that were sent to the provider.
+
+        You can choose to get only the CSR's that have a certificate assigned or only the CSR's
+          that don't.
+
+        Args:
+            fulfilled_only (bool): This option will discard CSRs that don't have certificates yet.
+            unfulfilled_only (bool): This option will discard CSRs that have certificates signed.
+
+        Returns:
+            List of CSR dictionaries. For example:
+            [
+                {
+                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
+                    "ca": false
+                }
+            ]
+        """
+        final_list = []
+        for csr in self._requirer_csrs:
+            assert isinstance(csr["certificate_signing_request"], str)
+            cert = self._find_certificate_in_relation_data(csr["certificate_signing_request"])
+            if (unfulfilled_only and cert) or (fulfilled_only and not cert):
+                continue
+            final_list.append(csr)
+
+        return final_list
+
     @staticmethod
     def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Checks whether relation data is valid based on json schema.
+        """Check whether relation data is valid based on json schema.
 
         Args:
             certificates_data: Certificate data in dict format.
@@ -1341,7 +1764,7 @@ class TLSCertificatesRequiresV2(Object):
             return False
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed events.
+        """Handle relation changed event.
 
         Goes through all providers certificates that match a requested CSR.
 
@@ -1426,7 +1849,7 @@ class TLSCertificatesRequiresV2(Object):
         return _get_closest_future_time(expiry_notification_time, expiry_time)
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handler triggered on relation broken event.
+        """Handle relation broken event.
 
         Emitting `all_certificates_invalidated` from `relation-broken` rather
         than `relation-departed` since certs are stored in app data.
@@ -1440,7 +1863,7 @@ class TLSCertificatesRequiresV2(Object):
         self.on.all_certificates_invalidated.emit()
 
     def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
-        """Triggered when a certificate is set to expire.
+        """Handle secret expired event.
 
         Loads the certificate from the secret, and will emit 1 of 2
         events.
@@ -1470,7 +1893,7 @@ class TLSCertificatesRequiresV2(Object):
             event.secret.remove_all_revisions()
             return
 
-        if datetime.utcnow() < expiry_time:
+        if datetime.now(timezone.utc) < expiry_time:
             logger.warning("Certificate almost expired")
             self.on.certificate_expiring.emit(
                 certificate=certificate_dict["certificate"],
@@ -1492,7 +1915,7 @@ class TLSCertificatesRequiresV2(Object):
             event.secret.remove_all_revisions()
 
     def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
-        """Returns the certificate that match the given CSR."""
+        """Return the certificate that match the given CSR."""
         for certificate_dict in self._provider_certificates:
             if certificate_dict["certificate_signing_request"] != csr:
                 continue
@@ -1500,7 +1923,7 @@ class TLSCertificatesRequiresV2(Object):
         return None
 
     def _on_update_status(self, event: UpdateStatusEvent) -> None:
-        """Triggered on update status event.
+        """Handle update status event.
 
         Goes through each certificate in the "certificates" relation and checks their expiry date.
         If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
@@ -1516,7 +1939,7 @@ class TLSCertificatesRequiresV2(Object):
             expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
             if not expiry_time:
                 continue
-            time_difference = expiry_time - datetime.utcnow()
+            time_difference = expiry_time - datetime.now(timezone.utc)
             if time_difference.total_seconds() < 0:
                 logger.warning("Certificate is expired")
                 self.on.certificate_invalidated.emit(
@@ -1534,37 +1957,3 @@ class TLSCertificatesRequiresV2(Object):
                     certificate=certificate_dict["certificate"],
                     expiry=expiry_time.isoformat(),
                 )
-
-
-def _get_closest_future_time(
-    expiry_notification_time: datetime, expiry_time: datetime
-) -> datetime:
-    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
-
-    Args:
-        expiry_notification_time (datetime): Notification time of impending expiration
-        expiry_time (datetime): Expiration time
-
-    Returns:
-        datetime: expiry_notification_time if not in the past, expiry_time otherwise
-    """
-    return (
-        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
-    )
-
-
-def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
-    """Extract expiry time from a certificate string.
-
-    Args:
-        certificate (str): x509 certificate as a string
-
-    Returns:
-        Optional[datetime]: Expiry datetime or None
-    """
-    try:
-        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after
-    except ValueError:
-        logger.warning("Could not load certificate.")
-        return None

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 r"""# Interface Library for ingress.
@@ -13,7 +13,7 @@ To get started using the library, you just need to fetch the library using `char
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.traefik_k8s.v1.ingress
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
 ```
 
 In the `metadata.yaml` of the charm, add the following:
@@ -50,26 +50,33 @@ class SomeCharm(CharmBase):
     def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
         logger.info("This app no longer has ingress")
 """
+
+import ipaddress
 import json
 import logging
 import socket
 import typing
 from dataclasses import dataclass
+from functools import partial
 from typing import (
     Any,
+    Callable,
     Dict,
     List,
     MutableMapping,
     Optional,
     Sequence,
     Tuple,
+    Union,
+    cast,
 )
 
 import pydantic
+from ops import EventBase
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
 from ops.framework import EventSource, Object, ObjectEvents, StoredState
 from ops.model import ModelError, Relation, Unit
-from pydantic import AnyHttpUrl, BaseModel, Field, validator
+from pydantic import AnyHttpUrl, BaseModel, Field
 
 # The unique Charmhub library identifier, never change it
 LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
@@ -79,9 +86,9 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 19
 
-PYDEPS = ["pydantic<2.0"]
+PYDEPS = ["pydantic"]
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -89,51 +96,145 @@ RELATION_INTERFACE = "ingress"
 log = logging.getLogger(__name__)
 BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
 
+PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+if PYDANTIC_IS_V1:  # noqa
+    from pydantic import validator
 
-class DatabagModel(BaseModel):
-    """Base databag model."""
+    input_validator = partial(validator, pre=True)
 
-    class Config:
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True, exclude_defaults=True)
+                return databag
+
+            for key, value in self.dict(by_alias=True, exclude_defaults=True).items():  # type: ignore  # noqa
+                databag[key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict, field_validator
+
+    input_validator = partial(field_validator, mode="before")  # type: ignore
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # tolerate additional keys in databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,
+        )  # type: ignore
         """Pydantic config."""
 
-        allow_population_by_field_name = True
-        """Allow instantiating this class by field name (instead of forcing alias)."""
+        # Annotating -> "DatabagModel" as the return type here doesn't sit well with pyright
+        # We are disabling this line for now and come back to it later.
+        @classmethod
+        def load(cls, databag: MutableMapping):  # type: ignore[no-untyped-def]
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
 
-    _NEST_UNDER = None
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.model_fields.items()}  # type: ignore
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                log.error(msg)
+                raise DataValidationError(msg) from e
 
-    @classmethod
-    def load(cls, databag: MutableMapping):
-        """Load this model from a Juju databag."""
-        if cls._NEST_UNDER:
-            return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                log.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
 
-        try:
-            data = {k: json.loads(v) for k, v in databag.items() if k not in BUILTIN_JUJU_KEYS}
-        except json.JSONDecodeError:
-            log.error(f"invalid databag contents: expecting json. {databag}")
-            raise
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True) -> Any:
+            """Write the contents of this model to Juju databag.
 
-        try:
-            return cls.parse_raw(json.dumps(data))  # type: ignore
-        except pydantic.ValidationError as e:
-            msg = f"failed to validate databag: {databag}"
-            log.error(msg, exc_info=True)
-            raise DataValidationError(msg) from e
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
 
-    def dump(self, databag: Optional[MutableMapping] = None):
-        """Write the contents of this model to Juju databag."""
-        if databag is None:
-            databag = {}
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
 
-        if self._NEST_UNDER:
-            databag[self._NEST_UNDER] = self.json()
-
-        dct = self.dict()
-        for key, field in self.__fields__.items():  # type: ignore
-            value = dct[key]
-            databag[field.alias or key] = json.dumps(value)
-
-        return databag
+            dct = self.model_dump(
+                mode="json",
+                by_alias=True,
+                exclude_defaults=True,  # type: ignore
+            )
+            databag.update({k: json.dumps(v) for k, v in dct.items()})
+            return databag
 
 
 # todo: import these models from charm-relation-interfaces/ingress/v2 instead of redeclaring them
@@ -146,7 +247,7 @@ class IngressUrl(BaseModel):
 class IngressProviderAppData(DatabagModel):
     """Ingress application databag schema."""
 
-    ingress: IngressUrl
+    ingress: Optional[IngressUrl] = None
 
 
 class ProviderSchema(BaseModel):
@@ -155,34 +256,60 @@ class ProviderSchema(BaseModel):
     app: IngressProviderAppData
 
 
+class IngressHealthCheck(BaseModel):
+    """HealthCheck schema for Ingress."""
+
+    path: str = Field(description="The health check endpoint path (required).")
+    scheme: Optional[str] = Field(
+        default=None, description="Replaces the server URL scheme for the health check endpoint."
+    )
+    hostname: Optional[str] = Field(
+        default=None, description="Hostname to be set in the health check request."
+    )
+    port: Optional[int] = Field(
+        default=None, description="Replaces the server URL port for the health check endpoint."
+    )
+    interval: str = Field(default="30s", description="Frequency of the health check calls.")
+    timeout: str = Field(default="5s", description="Maximum duration for a health check request.")
+
+
 class IngressRequirerAppData(DatabagModel):
     """Ingress requirer application databag model."""
 
     model: str = Field(description="The model the application is in.")
     name: str = Field(description="the name of the app requesting ingress.")
     port: int = Field(description="The port the app wishes to be exposed.")
+    healthcheck_params: Optional[IngressHealthCheck] = Field(
+        default=None, description="Optional health check configuration for ingress."
+    )
 
     # fields on top of vanilla 'ingress' interface:
     strip_prefix: Optional[bool] = Field(
-        description="Whether to strip the prefix from the ingress url.", alias="strip-prefix"
+        default=False,
+        description="Whether to strip the prefix from the ingress url.",
+        alias="strip-prefix",
     )
     redirect_https: Optional[bool] = Field(
-        description="Whether to redirect http traffic to https.", alias="redirect-https"
+        default=False,
+        description="Whether to redirect http traffic to https.",
+        alias="redirect-https",
     )
 
     scheme: Optional[str] = Field(
         default="http", description="What scheme to use in the generated ingress url"
     )
 
-    @validator("scheme", pre=True)
-    def validate_scheme(cls, scheme):  # noqa: N805  # pydantic wants 'cls' as first arg
+    # pydantic wants 'cls' as first arg
+    @input_validator("scheme")
+    def validate_scheme(cls, scheme: str) -> str:  # noqa: N805
         """Validate scheme arg."""
         if scheme not in {"http", "https", "h2c"}:
             raise ValueError("invalid scheme: should be one of `http|https|h2c`")
         return scheme
 
-    @validator("port", pre=True)
-    def validate_port(cls, port):  # noqa: N805  # pydantic wants 'cls' as first arg
+    # pydantic wants 'cls' as first arg
+    @input_validator("port")
+    def validate_port(cls, port: int) -> int:  # noqa: N805
         """Validate port."""
         assert isinstance(port, int), type(port)
         assert 0 < port < 65535, "port out of TCP range"
@@ -192,13 +319,38 @@ class IngressRequirerAppData(DatabagModel):
 class IngressRequirerUnitData(DatabagModel):
     """Ingress requirer unit databag model."""
 
-    host: str = Field(description="Hostname the unit wishes to be exposed.")
+    host: str = Field(description="Hostname at which the unit is reachable.")
+    ip: Optional[str] = Field(
+        None,
+        description="IP at which the unit is reachable, "
+        "IP can only be None if the IP information can't be retrieved from juju.",
+    )
 
-    @validator("host", pre=True)
-    def validate_host(cls, host):  # noqa: N805  # pydantic wants 'cls' as first arg
+    # pydantic wants 'cls' as first arg
+    @input_validator("host")
+    def validate_host(cls, host: str) -> str:  # noqa: N805
         """Validate host."""
         assert isinstance(host, str), type(host)
         return host
+
+    # pydantic wants 'cls' as first arg
+    @input_validator("ip")
+    def validate_ip(cls, ip: str) -> Optional[str]:  # noqa: N805
+        """Validate ip."""
+        if ip is None:
+            return None
+        if not isinstance(ip, str):
+            raise TypeError(f"got ip of type {type(ip)} instead of expected str")
+        try:
+            ipaddress.IPv4Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            pass
+        try:
+            ipaddress.IPv6Address(ip)
+            return ip
+        except ipaddress.AddressValueError:
+            raise ValueError(f"{ip!r} is not a valid ip address")
 
 
 class RequirerSchema(BaseModel):
@@ -236,24 +388,25 @@ class _IngressPerAppBase(Object):
         observe(rel_events.relation_created, self._handle_relation)
         observe(rel_events.relation_joined, self._handle_relation)
         observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
         observe(rel_events.relation_broken, self._handle_relation_broken)
         observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
         observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
 
     @property
-    def relations(self):
+    def relations(self) -> List[Relation]:
         """The list of Relation instances associated with this endpoint."""
         return list(self.charm.model.relations[self.relation_name])
 
-    def _handle_relation(self, event):
+    def _handle_relation(self, event: RelationEvent) -> None:
         """Subclasses should implement this method to handle a relation update."""
         pass
 
-    def _handle_relation_broken(self, event):
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
         """Subclasses should implement this method to handle a relation breaking."""
         pass
 
-    def _handle_upgrade_or_leader(self, event):
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
         """Subclasses should implement this method to handle upgrades or leadership change."""
         pass
 
@@ -263,10 +416,10 @@ class _IPAEvent(RelationEvent):
     __optional_kwargs__: Dict[str, Any] = {}
 
     @classmethod
-    def __attrs__(cls):
+    def __attrs__(cls):  # type: ignore
         return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
 
-    def __init__(self, handle, relation, *args, **kwargs):
+    def __init__(self, handle, relation, *args, **kwargs):  # type: ignore
         super().__init__(handle, relation)
 
         if not len(self.__args__) == len(args):
@@ -278,7 +431,7 @@ class _IPAEvent(RelationEvent):
             obj = kwargs.get(attr, default)
             setattr(self, attr, obj)
 
-    def snapshot(self):
+    def snapshot(self) -> Dict[str, Any]:
         dct = super().snapshot()
         for attr in self.__attrs__():
             obj = getattr(self, attr)
@@ -293,7 +446,7 @@ class _IPAEvent(RelationEvent):
 
         return dct
 
-    def restore(self, snapshot) -> None:
+    def restore(self, snapshot: Any) -> None:
         super().restore(snapshot)
         for attr, obj in snapshot.items():
             setattr(self, attr, obj)
@@ -317,11 +470,16 @@ class IngressPerAppDataRemovedEvent(RelationEvent):
     """Event representing that ingress data has been removed for an app."""
 
 
+class IngressPerAppEndpointsUpdatedEvent(RelationEvent):
+    """Event representing that the proxied endpoints have been updated."""
+
+
 class IngressPerAppProviderEvents(ObjectEvents):
     """Container for IPA Provider events."""
 
     data_provided = EventSource(IngressPerAppDataProvidedEvent)
     data_removed = EventSource(IngressPerAppDataRemovedEvent)
+    endpoints_updated = EventSource(IngressPerAppEndpointsUpdatedEvent)
 
 
 @dataclass
@@ -330,14 +488,6 @@ class IngressRequirerData:
 
     app: "IngressRequirerAppData"
     units: List["IngressRequirerUnitData"]
-
-
-class TlsProviderType(typing.Protocol):
-    """Placeholder."""
-
-    @property
-    def enabled(self) -> bool:  # type: ignore
-        """Placeholder."""
 
 
 class IngressPerAppProvider(_IngressPerAppBase):
@@ -359,7 +509,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         """
         super().__init__(charm, relation_name)
 
-    def _handle_relation(self, event):
+    def _handle_relation(self, event: RelationEvent) -> None:
         # created, joined or changed: if remote side has sent the required data:
         # notify listeners.
         if self.is_ready(event.relation):
@@ -368,15 +518,18 @@ class IngressPerAppProvider(_IngressPerAppBase):
                 event.relation,
                 data.app.name,
                 data.app.model,
-                [unit.dict() for unit in data.units],
+                [
+                    unit.dict() if PYDANTIC_IS_V1 else unit.model_dump(mode="json")
+                    for unit in data.units
+                ],
                 data.app.strip_prefix or False,
                 data.app.redirect_https or False,
             )
 
-    def _handle_relation_broken(self, event):
-        self.on.data_removed.emit(event.relation)  # type: ignore
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
+        self.on.data_removed.emit(event.relation, event.relation.app)  # type: ignore
 
-    def wipe_ingress_data(self, relation: Relation):
+    def wipe_ingress_data(self, relation: Relation) -> None:
         """Clear ingress data from relation."""
         assert self.unit.is_leader(), "only leaders can do this"
         try:
@@ -389,9 +542,10 @@ class IngressPerAppProvider(_IngressPerAppBase):
             )
             return
         del relation.data[self.app]["ingress"]
+        self.on.endpoints_updated.emit(relation=relation, app=relation.app)
 
     def _get_requirer_units_data(self, relation: Relation) -> List["IngressRequirerUnitData"]:
-        """Fetch and validate the requirer's app databag."""
+        """Fetch and validate the requirer's unit databag."""
         out: List["IngressRequirerUnitData"] = []
 
         unit: Unit
@@ -399,7 +553,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             databag = relation.data[unit]
             try:
                 data = IngressRequirerUnitData.load(databag)
-                out.append(data)
+                out.append(cast(IngressRequirerUnitData, data))
             except pydantic.ValidationError:
                 log.info(f"failed to validate remote unit data for {unit}")
                 raise
@@ -413,7 +567,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             raise NotReadyError(relation)
 
         databag = relation.data[app]
-        return IngressRequirerAppData.load(databag)
+        return cast(IngressRequirerAppData, IngressRequirerAppData.load(databag))
 
     def get_data(self, relation: Relation) -> IngressRequirerData:
         """Fetch the remote (requirer) app and units' databags."""
@@ -421,10 +575,12 @@ class IngressPerAppProvider(_IngressPerAppBase):
             return IngressRequirerData(
                 self._get_requirer_app_data(relation), self._get_requirer_units_data(relation)
             )
-        except (pydantic.ValidationError, DataValidationError, json.JSONDecodeError) as e:
-            raise DataValidationError("failed to validate ingress requirer data") from e
+        except (pydantic.ValidationError, DataValidationError) as e:
+            raise DataValidationError(
+                "failed to validate ingress requirer data: %s" % str(e)
+            ) from e
 
-    def is_ready(self, relation: Optional[Relation] = None):
+    def is_ready(self, relation: Optional[Relation] = None) -> bool:
         """The Provider is ready if the requirer has sent valid data."""
         if not relation:
             return any(map(self.is_ready, self.relations))
@@ -432,7 +588,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         try:
             self.get_data(relation)
         except (DataValidationError, NotReadyError) as e:
-            log.debug("Provider not ready; validation error encountered: %s" % str(e))
+            log.info("Provider not ready; validation error encountered: %s" % str(e))
             return False
         return True
 
@@ -452,13 +608,26 @@ class IngressPerAppProvider(_IngressPerAppBase):
 
         return IngressProviderAppData.load(databag)
 
-    def publish_url(self, relation: Relation, url: str):
+    def publish_url(self, relation: Relation, url: str) -> None:
         """Publish to the app databag the ingress url."""
         ingress_url = {"url": url}
-        IngressProviderAppData.parse_obj({"ingress": ingress_url}).dump(relation.data[self.app])
+        try:
+            IngressProviderAppData(ingress=ingress_url).dump(relation.data[self.app])  # type: ignore
+            self.on.endpoints_updated.emit(relation=relation, app=relation.app)
+        except pydantic.ValidationError as e:
+            # If we cannot validate the url as valid, publish an empty databag and log the error.
+            log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
+            log.error(
+                (
+                    f"url was not published to ingress relation for {relation.app}."
+                    f"This error is likely due to an error or misconfiguration of the"
+                    "charm calling this library."
+                )
+            )
+            IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
 
     @property
-    def proxied_endpoints(self) -> Dict[str, str]:
+    def proxied_endpoints(self) -> Dict[str, Dict[str, str]]:
         """Returns the ingress settings provided to applications by this IngressPerAppProvider.
 
         For example, when this IngressPerAppProvider has provided the
@@ -473,12 +642,15 @@ class IngressPerAppProvider(_IngressPerAppBase):
         }
         ```
         """
-        results = {}
+        results: Dict[str, Dict[str, str]] = {}
 
         for ingress_relation in self.relations:
             if not ingress_relation.app:
                 log.warning(
-                    f"no app in relation {ingress_relation} when fetching proxied endpoints: skipping"
+                    (
+                        f"no app in relation {ingress_relation} when fetching proxied endpoints:"
+                        "skipping"
+                    )
                 )
                 continue
             try:
@@ -494,7 +666,12 @@ class IngressPerAppProvider(_IngressPerAppBase):
                 log.warning(f"relation {ingress_relation} not ready yet: try again in some time.")
                 continue
 
-            results[ingress_relation.app.name] = ingress_data.ingress.dict()
+            # Validation above means ingress cannot be None, but type checker doesn't know that.
+            ingress = cast(IngressProviderAppData, ingress_data.ingress)
+            if PYDANTIC_IS_V1:
+                results[ingress_relation.app.name] = ingress.dict()
+            else:
+                results[ingress_relation.app.name] = ingress.model_dump(mode="json")
         return results
 
 
@@ -525,6 +702,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
     # used to prevent spurious urls to be sent out if the event we're currently
     # handling is a relation-broken one.
     _stored = StoredState()
+    _auto_data: Optional[Tuple[Optional[str], Optional[str], int]]
 
     def __init__(
         self,
@@ -532,12 +710,15 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         relation_name: str = DEFAULT_RELATION_NAME,
         *,
         host: Optional[str] = None,
+        ip: Optional[str] = None,
         port: Optional[int] = None,
         strip_prefix: bool = False,
         redirect_https: bool = False,
         # fixme: this is horrible UX.
-        #  shall we switch to manually calling provide_ingress_requirements with all args when ready?
-        scheme: typing.Callable[[], str] = lambda: "http",
+        # shall we switch to manually calling provide_ingress_requirements with all args when
+        # ready?
+        scheme: Union[Callable[[], str], str] = lambda: "http",
+        healthcheck_params: Optional[Dict[str, Any]] = None,
     ):
         """Constructor for IngressRequirer.
 
@@ -547,38 +728,57 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         All request args must be given as keyword args.
 
         Args:
-            charm: the charm that is instantiating the library.
-            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
-                relation must be of interface type `ingress` and have "limit: 1")
+            charm: The charm that is instantiating the library.
+            relation_name: The name of the relation endpoint to bind to (defaults to "ingress");
+                the relation must be of interface type "ingress" and have a limit of 1.
             host: Hostname to be used by the ingress provider to address the requiring
                 application; if unspecified, the default Kubernetes service name will be used.
-            strip_prefix: configure Traefik to strip the path prefix.
-            redirect_https: redirect incoming requests to HTTPS.
-            scheme: callable returning the scheme to use when constructing the ingress url.
+            ip: Alternative addressing method other than host to be used by the ingress provider;
+                if unspecified, the binding address from the Juju network API will be used.
+            healthcheck_params: Optional dictionary containing health check
+                configuration parameters conforming to the IngressHealthCheck schema.
+                The dictionary must include:
+                    - "path" (str): The health check endpoint path (required).
+                It may also include:
+                    - "scheme" (Optional[str]): Replaces the server URL scheme for the health check
+                        endpoint.
+                    - "hostname" (Optional[str]): Hostname to be set in the health check request.
+                    - "port" (Optional[int]): Replaces the server URL port for the health check
+                        endpoint.
+                    - "interval" (str): Frequency of the health check calls
+                        (defaults to "30s" if omitted).
+                    - "timeout" (str): Maximum duration for a health check request
+                        (defaults to "5s" if omitted).
+                If provided, "path" is required while "interval" and "timeout" will use Traefik's
+                    defaults when not specified.
+            strip_prefix: Configure Traefik to strip the path prefix.
+            redirect_https: Redirect incoming requests to HTTPS.
+            scheme: Either a callable that returns the scheme to use when constructing the ingress
+                URL, or a string if the scheme is known and stable at charm initialization.
 
         Request Args:
             port: the port of the service
         """
         super().__init__(charm, relation_name)
         self.charm: CharmBase = charm
+        self.healthcheck_params = healthcheck_params
         self.relation_name = relation_name
         self._strip_prefix = strip_prefix
         self._redirect_https = redirect_https
-        self._get_scheme = scheme
+        self._get_scheme = scheme if callable(scheme) else lambda: scheme
 
         self._stored.set_default(current_url=None)  # type: ignore
 
         # if instantiated with a port, and we are related, then
         # we immediately publish our ingress data  to speed up the process.
         if port:
-            self._auto_data = host, port
+            self._auto_data = host, ip, port
         else:
             self._auto_data = None
 
-    def _handle_relation(self, event):
+    def _handle_relation(self, event: RelationEvent) -> None:
         # created, joined or changed: if we have auto data: publish it
-        self._publish_auto_data(event.relation)
-
+        self._publish_auto_data()
         if self.is_ready():
             # Avoid spurious events, emit only when there is a NEW URL available
             new_url = (
@@ -590,16 +790,15 @@ class IngressPerAppRequirer(_IngressPerAppBase):
                 self._stored.current_url = new_url  # type: ignore
                 self.on.ready.emit(event.relation, new_url)  # type: ignore
 
-    def _handle_relation_broken(self, event):
+    def _handle_relation_broken(self, event: RelationEvent) -> None:
         self._stored.current_url = None  # type: ignore
-        self.on.revoked.emit(event.relation)  # type: ignore
+        self.on.revoked.emit(relation=event.relation, app=event.relation.app)  # type: ignore
 
-    def _handle_upgrade_or_leader(self, event):
+    def _handle_upgrade_or_leader(self, event: EventBase) -> None:
         """On upgrade/leadership change: ensure we publish the data we have."""
-        for relation in self.relations:
-            self._publish_auto_data(relation)
+        self._publish_auto_data()
 
-    def is_ready(self):
+    def is_ready(self) -> bool:
         """The Requirer is ready if the Provider has sent valid data."""
         try:
             return bool(self._get_url_from_relation_data())
@@ -607,58 +806,112 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             log.debug("Requirer not ready; validation error encountered: %s" % str(e))
             return False
 
-    def _publish_auto_data(self, relation: Relation):
+    def _publish_auto_data(self) -> None:
         if self._auto_data:
-            host, port = self._auto_data
-            self.provide_ingress_requirements(host=host, port=port)
+            host, ip, port = self._auto_data
+            self.provide_ingress_requirements(host=host, ip=ip, port=port)
 
-    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+    def provide_ingress_requirements(
+        self,
+        *,
+        scheme: Optional[str] = None,
+        host: Optional[str] = None,
+        ip: Optional[str] = None,
+        port: int,
+    ) -> None:
         """Publishes the data that Traefik needs to provide ingress.
 
         Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
             host: Hostname to be used by the ingress provider to address the
              requirer unit; if unspecified, FQDN will be used instead
+            ip: Alternative addressing method other than host to be used by the ingress provider.
+                if unspecified, binding address from juju network API will be used.
             port: the port of the service (required)
         """
-        # get only the leader to publish the data since we only
-        # require one unit to publish it -- it will not differ between units,
-        # unlike in ingress-per-unit.
-        assert self.relation, "no relation"
+        for relation in self.relations:
+            self._provide_ingress_requirements(scheme, host, ip, port, relation)
 
+    def _provide_ingress_requirements(
+        self,
+        scheme: Optional[str],
+        host: Optional[str],
+        ip: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
         if self.unit.is_leader():
-            app_databag = self.relation.data[self.app]
-            try:
-                IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
-                    model=self.model.name,
-                    name=self.app.name,
-                    scheme=self._get_scheme(),
-                    port=port,
-                    strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
-                    redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases
-                ).dump(app_databag)
-            except pydantic.ValidationError as e:
-                msg = "failed to validate app data"
-                log.info(msg, exc_info=True)  # log to INFO because this might be expected
-                raise DataValidationError(msg) from e
+            self._publish_app_data(scheme, port, relation)
 
+        self._publish_unit_data(host, ip, relation)
+
+    def _publish_unit_data(
+        self,
+        host: Optional[str],
+        ip: Optional[str],
+        relation: Relation,
+    ) -> None:
         if not host:
             host = socket.getfqdn()
 
-        unit_databag = self.relation.data[self.unit]
+        if ip is None:
+            network_binding = self.charm.model.get_binding(relation)
+            if (
+                network_binding is not None
+                and (bind_address := network_binding.network.bind_address) is not None
+            ):
+                ip = str(bind_address)
+            else:
+                log.error("failed to retrieve ip information from juju")
+
+        unit_databag = relation.data[self.unit]
         try:
-            IngressRequirerUnitData(host=host).dump(unit_databag)
+            IngressRequirerUnitData(host=host, ip=ip).dump(unit_databag)
         except pydantic.ValidationError as e:
             msg = "failed to validate unit data"
             log.info(msg, exc_info=True)  # log to INFO because this might be expected
             raise DataValidationError(msg) from e
 
+    def _publish_app_data(
+        self,
+        scheme: Optional[str],
+        port: int,
+        relation: Relation,
+    ) -> None:
+        # assumes leadership!
+        app_databag = relation.data[self.app]
+
+        if not scheme:
+            # If scheme was not provided, use the one given to the constructor.
+            scheme = self._get_scheme()
+
+        try:
+            # Ignore pyright errors since pyright does not like aliases.
+            IngressRequirerAppData(  # type: ignore
+                model=self.model.name,
+                name=self.app.name,
+                scheme=scheme,
+                port=port,
+                strip_prefix=self._strip_prefix,  # type: ignore
+                redirect_https=self._redirect_https,  # type: ignore
+                healthcheck_params=(
+                    IngressHealthCheck(**self.healthcheck_params)
+                    if self.healthcheck_params
+                    else None
+                ),
+            ).dump(app_databag)
+        except pydantic.ValidationError as e:
+            msg = "failed to validate app data"
+            log.info(msg, exc_info=True)  # log to INFO because this might be expected
+            raise DataValidationError(msg) from e
+
     @property
-    def relation(self):
+    def relation(self) -> Optional[Relation]:
         """The established Relation instance, or None."""
         return self.relations[0] if self.relations else None
 
     def _get_url_from_relation_data(self) -> Optional[str]:
-        """The full ingress URL to reach the current unit.
+        """The full ingress URL to reach the charm application.
 
         Returns None if the URL isn't available yet.
         """
@@ -679,11 +932,15 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         if not databag:  # not ready yet
             return None
 
-        return str(IngressProviderAppData.load(databag).ingress.url)
+        ingress = cast(IngressProviderAppData, IngressProviderAppData.load(databag)).ingress
+        if ingress is None:
+            return None
+
+        return str(ingress.url)
 
     @property
     def url(self) -> Optional[str]:
-        """The full ingress URL to reach the current unit.
+        """The full ingress URL to reach the charm application.
 
         Returns None if the URL isn't available yet.
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cryptography==41.0.3
+cryptography==46.0.3
 jinja2==3.1.6
 jsonschema==4.26.0
 lightkube>=0.10.1,<1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 cryptography==41.0.3
-rpds-py==0.9.2
-jinja2
-jsonschema
-lightkube
-lightkube-models
-ops
-pydantic<2.0
-ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@da891c403864482688ec767a964218e5857f0e49#subdirectory=ops
+jinja2==3.1.6
+jsonschema==4.26.0
+lightkube>=0.10.1,<1.0.0
+ops==3.5.0
+pydantic==1.10.26
+ops.interface_tls_certificates @ git+https://github.com/charmed-kubernetes/interface-tls-certificates.git@236e089493c96feac5ea1a8617b1059a4477a04e#subdirectory=ops

--- a/tests/integration/test_kubernetes_dashboard.py
+++ b/tests/integration/test_kubernetes_dashboard.py
@@ -102,7 +102,7 @@ async def test_dashboard_is_up(ops_test: OpsTest):
 
 
 async def test_ingress_integration(ops_test: OpsTest):
-    await ops_test.model.deploy("traefik-k8s", channel="edge", trust=True)
+    await ops_test.model.deploy("traefik-k8s", channel="stable", trust=True)
     await ops_test.model.integrate("traefik-k8s:certificates", "tls-certificates:certificates")
     await ops_test.model.integrate("dashboard:ingress", "traefik-k8s:ingress")
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
This pull request updates the `charmcraft.yaml` configuration to streamline build targets and improve the build process for the charm. The most significant changes are the removal of the `armhf` architecture build/run targets and enhancements to the build step to include versioning and new dependencies.

**Build target updates:**
- Removed support for building and running on the `armhf` architecture, simplifying the supported architectures to focus on more commonly used ones.

**Build process improvements:**
- Switched the charm build process to use the `charm` plugin and added an `override-build` step that writes the current git commit hash to a `version` file for better version tracking.
- Replaced the `charm-python-packages` list with `charm-binary-python-packages`, now including `maturin` as a dependency. This change likely supports building Rust extensions or similar binary components.