### PR TITLE
Use operator-workflows to auto update charm libs

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -2,7 +2,7 @@ name: Auto-update Charm Libraries
 on:
   # Manual trigger
   workflow_dispatch:
-  # Check regularly the upstream every four hours
+  # Check upstream daily at 01:00 UTC
   schedule:
     - cron: "0 1 * * *"
   pull_request:

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -4,47 +4,28 @@ on:
   workflow_dispatch:
   # Check regularly the upstream every four hours
   schedule:
-    - cron: "0 0,4,8,12,16,20 * * *"
+    - cron: "0 1 * * *"
+  pull_request:
+    paths:
+      - .github/workflows/update-libs.yaml
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
 jobs:
-  update-lib:
-    name: Check libraries
-    runs-on: ubuntu-latest
+  charmcraft-channel:
+    runs-on: ubuntu-24.04
+    outputs:
+      channel: ${{ steps.charmcraft.outputs.channel }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Read charmcraft version file
-        id: charmcraft
-        run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
-      - name: Checkout
-        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
-        with:
-          fetch-depth: 0
-
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@e60e65a61eb6b7459716e55c7c7f8bc97d6ff02c # 2.2.5
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          charmcraft-channel: ${{ steps.charmcraft.outputs.channel }}
-
-      - uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1
-        id: generate-token
-        with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_KEY }}
-
-      - name: Create a PR for local changes
-        uses: peter-evans/create-pull-request@5b4a9f6a9e2af26e5f02351490b90d01eb8ec1e5 # v5
-        id: cpr
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
-          commit-message: "chore: bump charm libraries"
-          committer: "Github Actions <github-actions@github.com>"
-          author: "Github Actions <github-actions@github.com>"
-          title: "Bump charm libraries"
-          body: Automated action to fetch latest version of charm libraries.
-          branch: "auto-libs"
-          delete-branch: true
-          reviewers: jnsgruk
-          assignees: jnsgruk
+    - uses: actions/checkout@v6
+    - id: charmcraft
+      run: echo "channel=$(cat .charmcraft-channel)" >> $GITHUB_OUTPUT
+  auto-update-libs:
+    needs: [charmcraft-channel]
+    uses: canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main
+    secrets: inherit
+    with:
+      charmcraft-channel: ${{ needs.charmcraft-channel.outputs.channel }}


### PR DESCRIPTION
This pull request refactors the `.github/workflows/update-libs.yaml` workflow to improve maintainability and automation. The workflow now uses a reusable workflow for updating charm libraries and streamlines how the charmcraft channel is determined. It also adjusts the schedule for checking updates and adds a trigger for pull requests affecting the workflow file.

Workflow configuration improvements:

* Changed the cron schedule to run the update check once daily at 1 AM instead of every four hours, and added a trigger for pull requests affecting `.github/workflows/update-libs.yaml`.

Workflow structure and automation:

* Split the workflow into two jobs: `charmcraft-channel` (to read the charmcraft channel) and `auto-update-libs` (to run the reusable workflow for updating charm libraries).
* Replaced the manual update logic with a call to `canonical/operator-workflows/.github/workflows/auto_update_charm_libs.yaml@main`, inheriting secrets and passing the channel as an input.
* Removed steps for checking libraries, generating GitHub app tokens, and creating pull requests, as these are now handled by the reusable workflow.