### PR TITLE
docs: add deprecation notice — addon removed in CK 1.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # Kubernetes Dashboard Operator
 
+> **⚠️ Deprecation notice**
+>
+> The Kubernetes Dashboard is no longer maintained or distributed as part of Charmed Kubernetes
+> as of CK 1.36. This operator charm receives no further updates from Canonical. Canonical does
+> not recommend running the Kubernetes Dashboard in production environments.
+>
+> If you still need the dashboard, you can deploy it directly from the upstream project —
+> accepting that support and security patching become your own responsibility:
+>
+> ```bash
+> helm upgrade --install kubernetes-dashboard kubernetes-dashboard \
+>   --repo https://kubernetes.github.io/dashboard \
+>   --namespace kubernetes-dashboard --create-namespace
+> ```
+
+
 ## Description
 
 Dashboard is a web-based Kubernetes user interface. You can use Dashboard to deploy containerized

--- a/README.md
+++ b/README.md
@@ -6,14 +6,10 @@
 > as of CK 1.36. This operator charm receives no further updates from Canonical. Canonical does
 > not recommend running the Kubernetes Dashboard in production environments.
 >
-> If you still need the dashboard, you can deploy it directly from the upstream project —
-> accepting that support and security patching become your own responsibility:
->
-> ```bash
-> helm upgrade --install kubernetes-dashboard kubernetes-dashboard \
->   --repo https://kubernetes.github.io/dashboard \
->   --namespace kubernetes-dashboard --create-namespace
-> ```
+> If you still need the dashboard, refer to the
+> [upstream Kubernetes Dashboard documentation](https://kubernetes.io/docs/tasks/access-application-cluster/web-ui-dashboard/)
+> for installation instructions — noting that the upstream project itself is now deprecated
+> and unmaintained.
 
 
 ## Description


### PR DESCRIPTION
## Summary

The Kubernetes Dashboard addon was removed from Charmed Kubernetes in CK 1.36. This PR adds a prominent deprecation notice to the README so that anyone landing on this repo understands the current support status.

## Changes

- **`README.md`**: Added a blockquote deprecation notice immediately below the title. States that the charm receives no further updates from Canonical, advises against production use, and provides the upstream Helm-based migration path for operators who still need the dashboard.

## Scope

Docs-only. No code modified.